### PR TITLE
added event-trigger time delay parameter

### DIFF
--- a/event_controller.php
+++ b/event_controller.php
@@ -29,6 +29,7 @@
       $eventfeed = intval(get('eventfeed'));
       $eventtype = intval(get('eventtype'));
       $eventvalue = floatval(get('eventvalue'));
+      $triggerdelay = intval(get('triggerdelay'));
       $action = intval(get('action'));
       $setfeed = intval(get('setfeed'));
       $setemail = get('setemail');
@@ -38,7 +39,7 @@
       $priority = get('priority');
       $message = get('message');
 
-      $event->add($userid,$eventfeed,$eventtype,$eventvalue,$action,$setfeed,$setemail,$setvalue,$callcurl,$message,$mutetime,$priority);
+      $event->add($userid,$eventfeed,$eventtype,$eventvalue,$triggerdelay,$action,$setfeed,$setemail,$setvalue,$callcurl,$message,$mutetime,$priority);
       $result = "Event added";
     }
     if ($route->action == 'edit' && $session['write'])
@@ -47,6 +48,7 @@
       $eventfeed = intval(get('eventfeed'));
       $eventtype = intval(get('eventtype'));
       $eventvalue = floatval(get('eventvalue'));
+      $triggerdelay = intval(get('triggerdelay'));
       $action = intval(get('action'));
       $setfeed = intval(get('setfeed'));
       $setemail = get('setemail');
@@ -56,7 +58,7 @@
       $priority = get('priority');
       $message = get('message');
 
-      $event->update($userid,$eventid,$eventfeed,$eventtype,$eventvalue,$action,$setfeed,$setemail,$setvalue,$callcurl,$message,$mutetime,$priority);
+      $event->update($userid,$eventid,$eventfeed,$eventtype,$eventvalue,$triggerdelay,$action,$setfeed,$setemail,$setvalue,$callcurl,$message,$mutetime,$priority);
       $result = "Event updated";
     }
 

--- a/event_list.php
+++ b/event_list.php
@@ -50,6 +50,7 @@
     if ($item['eventtype']==7) echo "manual update";
     ?></td>
     <td><?php echo $item['eventvalue']; ?></td>
+    <td><?php echo $item['triggerdelay']; ?> secs</td>
     <td>
     <?php
     $state = false;
@@ -89,10 +90,12 @@
     <td><?php if ($item['action']==2) echo $item['callcurl']; ?></td>
     <td><?php echo $item['message']; ?> </td>
     <td><?php echo $item['mutetime']; ?> secs</td>
-   <td><div class="editevent btn"
+
+    <td><div class="editevent btn"
             eventid="<?php echo $item['id']; ?>"
             eventtype="<?php echo $item['eventtype']; ?>"
             eventvalue="<?php echo $item['eventvalue']; ?>"
+            triggerdelay="<?php echo $item['triggerdelay']; ?>"
             action="<?php echo $item['action']; ?>"
             setvalue="<?php echo $item['setvalue']; ?>"
             setemail="<?php echo $item['setemail']; ?>"
@@ -101,6 +104,7 @@
             callcurl="<?php echo $item['callcurl']; ?>"
             message="<?php echo $item['message']; ?>"
             mutetime="<?php echo $item['mutetime']; ?>"
+            priority="<?php echo $item['priority']; ?>"
 
         >Edit</div></td>
 
@@ -149,6 +153,24 @@
           <input id="eventvalue" name="eventvalue" type="text" style="width:60px; margin:0px;" />
       </span>
 
+      <span style="font-weight:bold;" >for</span>
+
+      <select id="triggerdelay" name="triggerdelay" style="width:100px; margin:0px;">
+          <option value="0">0 secs</option>
+          <option value="5">5 secs</option>
+          <option value="15">15 secs</option>
+          <option value="30">30 secs</option>
+          <option value="60">1 min</option>
+          <option value="300">5 min</option>
+          <option value="600">10 min</option>
+          <option value="1800">30 min</option>
+          <option value="3600">1 hour</option>
+          <option value="14400">3 hour</option>
+          <option value="28800">6 hour</option>
+          <option value="57600">12 hour</option>
+          <option value="86400">24 hour</option>
+      </select>
+
       <span style="font-weight:bold;" >: </span>
 
       <select id="action" name="action" style="width:100px; margin:0px;">
@@ -180,7 +202,7 @@
           <input id="message" name="message" type="text" style="width:180px; margin:0px;" value="Feed is {value}"/>
       </span>
 
-      <span id="not-priority" style="font-weight:bold;" > priority
+      <span id="priority" style="font-weight:bold;" > priority
           <select id="action-priority" name="priority" style="width:100px; margin:0px;">
               <option value="-2">Very Low</option>
               <option value="-1">Moderate</option>
@@ -270,9 +292,11 @@
     $("#setvalue").val($(this).attr("setvalue"));
     $("#setemail").val($(this).attr("setemail"));
     $("#callcurl").val($(this).attr("callcurl"));
+    $("#triggerdelay").val($(this).attr("triggerdelay"));
     $("#action").val($(this).attr("action"));
     $("#message").val($(this).attr("message"));
     $("#mutetime").val($(this).attr("mutetime"));
+    $("#priority").val($(this).attr("priority"));
     $("#eventtype").change();
     $("#action").change();
     return false;

--- a/event_schema.php
+++ b/event_schema.php
@@ -19,6 +19,8 @@ $schema['event'] = array(
   'userid' => array('type' => 'int(11)'),
   'eventfeed' => array('type' => 'int(11)'),
   'eventtype' => array('type' => 'int(11)'),
+  'triggerdelay' => array('type' => 'int(11)'),
+  'lastuntriggeredtime' => array('type' => 'int(11)'),
   'eventvalue' => array('type' => 'float'),
   'action' => array('type' => 'int(11)'),
   'setfeed' => array('type' => 'int(11)'),


### PR DESCRIPTION
I came across a need to delay an alert for a certain amount of time before actually sending the alert. I thought this might be a handy feature for others and that you may want to add it.

I'm monitoring a dehumidifier's power usage. When it turns off, I was trying to send an alert, indicating the unit was full (power goes down when it's not running of course). However, the unit sometimes cycles on and off depending on the humidity. It may turn off only for a minute and then turn back on for an hour. I came up with the idea to set a delay before the event message is actually sent. So it would only send a message after one hour of the condition being true. Each time the condition is indicated as false, it resets a timestamp that's used to calculate if the time delay period has elapsed.

I tested it with a frequently updating value (uptime) from an arduino node. It  seems to work as expected, and seems to behave nicely when using a "Mutetime" parameter too.

The following is the solution I came up with. The downside might be that it updates a time value in the database each time the feed check is processed (seems to be every time a value is sent from the node that has an event  entry attached to it), but I couldn't figure out how to get around this easily. If there's another solution that's more elegant, by all means, use that one! I tried to leave as much code alone as I could manage. If there's  another way to make it cleaner, that's great!
